### PR TITLE
Add Support for Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,9 @@ set(PA_DLL_LINK_WITH_STATIC_RUNTIME ON CACHE BOOL "" FORCE)
 set(PA_BUILD_SHARED OFF CACHE BOOL "" FORCE)
 add_subdirectory(3rdparty/portaudio)
 set_target_properties(portaudio_static PROPERTIES DEBUG_POSTFIX -d)
-set_target_properties(portaudio_static PROPERTIES POSITION_INDEPENDENT_CODE ON)
+if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+    set_target_properties(portaudio_static PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif()
 
 #===============================================================================
 # Syntacts Static C++ Library
@@ -128,7 +130,6 @@ set_target_properties(portaudio_static PROPERTIES POSITION_INDEPENDENT_CODE ON)
 add_library(syntacts "")
 add_library(syntacts::syntacts ALIAS syntacts)
 set_target_properties(syntacts PROPERTIES CXX_STANDARD 17 DEBUG_POSTFIX -d)
-set_target_properties(syntacts PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_compile_features(syntacts PUBLIC cxx_std_17)
 if (MSVC)
     set_target_properties(syntacts PROPERTIES COMPILE_FLAGS "/bigobj")
@@ -144,6 +145,8 @@ target_compile_definitions(syntacts
 if (WIN32 AND PA_USE_ASIO)
     message("Building Syntacts with ASIO support")
     target_compile_definitions(syntacts PUBLIC PA_USE_ASIO)
+elseif (CMAKE_SYSTEM_NAME MATCHES "Linux")
+    set_target_properties(syntacts PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()
 target_include_directories(syntacts
 	PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ set(PA_DLL_LINK_WITH_STATIC_RUNTIME ON CACHE BOOL "" FORCE)
 set(PA_BUILD_SHARED OFF CACHE BOOL "" FORCE)
 add_subdirectory(3rdparty/portaudio)
 set_target_properties(portaudio_static PROPERTIES DEBUG_POSTFIX -d)
+set_target_properties(portaudio_static PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 #===============================================================================
 # Syntacts Static C++ Library
@@ -127,6 +128,7 @@ set_target_properties(portaudio_static PROPERTIES DEBUG_POSTFIX -d)
 add_library(syntacts "")
 add_library(syntacts::syntacts ALIAS syntacts)
 set_target_properties(syntacts PROPERTIES CXX_STANDARD 17 DEBUG_POSTFIX -d)
+set_target_properties(syntacts PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_compile_features(syntacts PUBLIC cxx_std_17)
 if (MSVC)
     set_target_properties(syntacts PROPERTIES COMPILE_FLAGS "/bigobj")

--- a/gui/src/Gui.cpp
+++ b/gui/src/Gui.cpp
@@ -46,6 +46,9 @@ const std::string &Gui::saveDir()
 #elif __APPLE__
     static fs::path p = std::string(getenv("HOME")) + "/Library/Syntacts/GUI/";
     static std::string dir = p.generic_string();
+#elif __linux__
+    static fs::path p = std::string(std::getenv("HOME")) + "/Syntacts/GUI/";
+    static std::string dir = p.generic_string();
 #else
     static std::string dir = "";
 #endif

--- a/python/syntacts.py
+++ b/python/syntacts.py
@@ -32,6 +32,8 @@ if platform.uname()[0] == "Windows":
     _lib_name = "./syntacts_c.dll"
 elif platform.uname()[0] == "Darwin":
     _lib_name = "./libsyntacts_c.dylib"
+elif platform.uname()[0] == "Linux":
+    _lib_name = "./libsyntacts_c.so"
 
 _tact = cdll.LoadLibrary(_lib_name)
 

--- a/src/Tact/Library.cpp
+++ b/src/Tact/Library.cpp
@@ -159,6 +159,8 @@ const std::string &getLibraryDirectory()
     static fs::path dirPath = std::string(std::getenv("APPDATA")) + std::string("\\Syntacts\\Library\\");
 #elif __APPLE__
     static fs::path dirPath = std::string(getenv("HOME")) + "/Library/Syntacts/Library/";
+#elif __linux__
+    static fs::path dirPath = std::string(std::getenv("HOME")) + "/Syntacts/Library/";
 #else
     static fs::path dirPath = "";
 #endif

--- a/tools/package_release.py
+++ b/tools/package_release.py
@@ -77,3 +77,35 @@ elif platform == 'darwin':
     copytree("../unity/SyntactsDemo/ProjectSettings",output_dir+"/unity/SyntactsDemo/ProjectSettings",ignore=ignore_patterns(".gitignore"))
     # create zip
     make_archive(output_dir, 'zip', output_dir)
+elif platform == 'linux':
+    unity_exe = "$HOME/Unity/Hub/Editor/2019.4.11f1/Editor/Unity"
+    version    = sys.argv[1]
+    output_dir = sys.argv[2] + "/" + "syntacts_v" + version + "_linux"
+    # delete existing
+    if os.path.exists(output_dir) and os.path.isdir(output_dir):
+        rmtree(output_dir)
+    # make release folder
+    os.mkdir(output_dir)
+    # package license
+    copy2("../LICENSE", output_dir)
+    copy2("../README.md", output_dir)
+    # package GUI
+    copy2("../build/gui/syntacts_gui",output_dir)
+    # package c
+    os.mkdir(output_dir + "/c")
+    copy2("../c/syntacts.h",output_dir + "/c")
+    copy2("../build/c/libsyntacts_c.so",output_dir + "/c")
+    # package csharp
+    copytree("../csharp",output_dir+"/csharp",ignore=ignore_patterns(".gitignore","*-d.dll","bin","obj"))
+    # package python
+    copytree("../python",output_dir+"/python",ignore=ignore_patterns(".gitignore","*-d.dll","__pycache__"))
+    # make unitypackage
+    os.mkdir(output_dir + "/unity")
+    unity_cmd = ' -quit -batchmode -nographics -projectPath "../unity/SyntactsDemo" -exportPackage "Assets/Syntacts" "' + output_dir + '/unity/syntacts.unitypackage"'
+    os.system(unity_exe + unity_cmd)
+    # package unity demo
+    copytree("../unity/SyntactsDemo/Assets",output_dir+"/unity/SyntactsDemo/Assets",ignore=ignore_patterns(".gitignore"))
+    copytree("../unity/SyntactsDemo/Packages",output_dir+"/unity/SyntactsDemo/Packages",ignore=ignore_patterns(".gitignore"))
+    copytree("../unity/SyntactsDemo/ProjectSettings",output_dir+"/unity/SyntactsDemo/ProjectSettings",ignore=ignore_patterns(".gitignore"))
+    # create zip
+    make_archive(output_dir, 'zip', output_dir)


### PR DESCRIPTION
A few minor tweaks to ensure the library builds and the GUI can be launched on Linux (or at the very least Debian bullseye with Clang v9.0.1 and GCC v10.2). Changes are:

* Set `POSITION_INDEPENDENT_CODE` to fix linker errors for the `syntacts` and `portaudio_static` targets.
* In places where OS-specific paths are used, add a statement for `__linux__` that creates directories for Syntacts under the user's HOME directory.
* For Python, load `libsyntacts_c.so`.

Are there any specific tests that should be run to ensure features are working correctly?